### PR TITLE
(SIMP-3111) Don't comment out all 'at' users

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Apr 26 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 0.0.3
+- Ensure that entries in 'at.allow' are not commented out by default
+- Updated the Gemfile to pin to the latest working Beaker
+
 * Thu Mar 02 2017 Nick Miller <nick.miller@onxypoint.com> - 0.0.2
 - Manage at package
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,7 @@ group :development do
 end
 
 group :system_tests do
-  # This patch is required to fix Beaker's broken `aio` handling
-  gem 'beaker', :git => 'https://github.com/trevor-vaughan/beaker.git', :branch => 'BKR-931-2.51.0'
-  gem 'beaker-rspec'
+  gem 'beaker', '>= 3.15.0', '< 4.0.0'
+  gem 'beaker-rspec', '>= 6.1.0', '< 7.0.0'
   gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,8 @@
 #   An array of additional at users, using the defiend type at::user.
 #
 class at (
-  Array[String] $users = []
+  Array[String] $users = [],
+  String        $package_ensure = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })
 ) {
 
   $users.each |String $user| {
@@ -33,7 +34,7 @@ class at (
     require => Package['at']
   }
 
-  package { 'at': ensure => latest }
+  package { 'at': ensure => $package_ensure }
 
   service { 'atd':
     ensure     => 'running',

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -9,7 +9,7 @@ define at::user {
   $_name = regsubst($name,'/','__')
 
   simpcat_fragment { "at+${_name}.user":
-    content =>  "#${name}\n"
+    content =>  "${name}\n"
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-at",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author":  "SIMP Team",
   "summary": "A SIMP Puppet module for managing at",
   "license": "Apache-2.0",

--- a/spec/acceptance/suites/default/at_spec.rb
+++ b/spec/acceptance/suites/default/at_spec.rb
@@ -3,21 +3,6 @@ require 'spec_helper_acceptance'
 test_name 'at'
 
 describe 'at class' do
-  before(:context) do
-    hosts.each do |host|
-      interfaces = fact_on(host, 'interfaces').strip.split(',')
-      interfaces.delete_if do |x|
-        x =~ /^lo/
-      end
-
-      interfaces.each do |iface|
-        if fact_on(host, "ipaddress_#{iface}").strip.empty?
-          on(host, "ifup #{iface}", :accept_all_exit_codes => true)
-        end
-      end
-    end
-  end
-
   let(:manifest) {
     <<-EOS
       include 'at'
@@ -34,6 +19,5 @@ describe 'at class' do
         apply_manifest_on(host, manifest, :catch_changes => true)
       end
     end
-
   end
 end

--- a/spec/defines/user_spec.rb
+++ b/spec/defines/user_spec.rb
@@ -10,12 +10,12 @@ describe 'at::user' do
 
         context 'with default parameters' do
           let(:title) { 'foobar' }
-          it { is_expected.to create_simpcat_fragment('at+foobar.user') }
+          it { is_expected.to create_simpcat_fragment('at+foobar.user').with_content("#{title}\n") }
         end
 
         context 'with a name that requires substitution' do
           let(:title) { 'foo/bar' }
-          it { is_expected.to create_simpcat_fragment('at+foo__bar.user') }
+          it { is_expected.to create_simpcat_fragment('at+foo__bar.user').with_content("#{title}\n") }
         end
 
       end


### PR DESCRIPTION
There was a bug in the at::user code that was commenting out any user
that was added to the file.

SIMP-3111 #close