### PR TITLE
(SIMP-10204) Ensure testing with CentOS 8.4

### DIFF
--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -21,7 +21,7 @@ HOSTS:
       - agent
       - client
     platform:   el-8-x86_64
-    box:        centos/8
+    box:        generic/centos8
     hypervisor: <%= hypervisor %>
 
 CONFIG:


### PR DESCRIPTION
  - update the EL8 nodes in the acceptance tests
    to run with generic/centos8 to make sure they using
    CentOS 8.4

SIMP-10204 #comment at updates
SIMP-10208 #close