### PR TITLE
Finalize RockyLinux 8 support

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -117,6 +117,7 @@ jobs:
             puppet_version: '~> 8.0'
             ruby_version: 3.1
             experimental: true
+      fail-fast: false
     env:
       PUPPET_VERSION: ${{matrix.puppet.puppet_version}}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 /junit
 /log
 /doc
+/Gemfile.lock

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -340,6 +340,7 @@ pup7.pe-unit:
   <<: *pup_7_pe
   <<: *unit_tests
 
+# Commenting until Puppet 8 is released
 #pup8.x-unit:
 #  <<: *pup_8_x
 #  <<: *unit_tests

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,7 +10,7 @@
 
 ### Defined types
 
-* [`at::user`](#atuser): Add the user $name to /etc/at.allow
+* [`at::user`](#at--user): Add the user $name to /etc/at.allow
 
 ## Classes
 
@@ -22,10 +22,10 @@ This class manages /etc/at.allow and /etc/at.deny and the atd service.
 
 The following parameters are available in the `at` class:
 
-* [`users`](#users)
-* [`package_ensure`](#package_ensure)
+* [`users`](#-at--users)
+* [`package_ensure`](#-at--package_ensure)
 
-##### <a name="users"></a>`users`
+##### <a name="-at--users"></a>`users`
 
 Data type: `Array[String]`
 
@@ -33,7 +33,7 @@ An array of additional at users, using the defiend type ``at::user``
 
 Default value: `[]`
 
-##### <a name="package_ensure"></a>`package_ensure`
+##### <a name="-at--package_ensure"></a>`package_ensure`
 
 Data type: `String`
 
@@ -43,7 +43,7 @@ Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value
 
 ## Defined types
 
-### <a name="atuser"></a>`at::user`
+### <a name="at--user"></a>`at::user`
 
 Add the user $name to /etc/at.allow
 
@@ -51,9 +51,9 @@ Add the user $name to /etc/at.allow
 
 The following parameters are available in the `at::user` defined type:
 
-* [`name`](#name)
+* [`name`](#-at--user--name)
 
-##### <a name="name"></a>`name`
+##### <a name="-at--user--name"></a>`name`
 
 The user to add to /etc/at.allow
 


### PR DESCRIPTION
This patch adds support for RockyLinux 8

The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.