### PR TITLE
Gate atd service on package ensure.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -37,9 +37,10 @@ Default value: `[]`
 
 Data type: `String`
 
-The value of ``ensure`` for package resources
+The value of ``ensure`` for package resources. The ``atd`` service is only
+managed when the package is expected to be present (not ``absent`` or ``purged``).
 
-Default value: `simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' })`
+Default value: `'installed'`
 
 ## Defined types
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,12 +4,15 @@
 #   An array of additional at users, using the defiend type ``at::user``
 #
 # @param package_ensure
-#   The value of ``ensure`` for package resources
+#   The value of ``ensure`` for package resources. The ``atd`` service is only
+#   managed when the package is expected to be present (not ``absent`` or ``purged``).
 #
 class at (
   Array[String] $users = [],
   String        $package_ensure = 'installed'
 ) {
+  $manage_service = !($package_ensure in ['absent', 'purged'])
+
   $users.each |String $user| {
     at::user { $user: }
   }
@@ -30,11 +33,13 @@ class at (
 
   package { 'at': ensure => $package_ensure }
 
-  service { 'atd':
-    ensure     => 'running',
-    enable     => true,
-    hasstatus  => true,
-    hasrestart => true,
-    require    => Package['at'],
+  if $manage_service {
+    service { 'atd':
+      ensure     => 'running',
+      enable     => true,
+      hasstatus  => true,
+      hasrestart => true,
+      require    => Package['at'],
+    }
   }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -35,6 +35,35 @@ describe 'at' do
           it { is_expected.to create_at__user('foo') }
           it { is_expected.to create_at__user('bar') }
         end
+
+        context 'with package_ensure => absent' do
+          let(:params) { { package_ensure: 'absent' } }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_service('atd') }
+        end
+
+        context 'with package_ensure => purged' do
+          let(:params) { { package_ensure: 'purged' } }
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.not_to contain_service('atd') }
+        end
+
+        context 'with package_ensure => latest' do
+          let(:params) { { package_ensure: 'latest' } }
+
+          it { is_expected.to compile.with_all_deps }
+          it do
+            is_expected.to create_service('atd')
+              .with(
+                ensure: 'running',
+                enable: true,
+                hasstatus: true,
+                hasrestart: true,
+              )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
PROBLEM:
The at class always declared service { 'atd': ensure => 'running' }, even when package_ensure was absent or purged. That made Puppet try to manage a running service while the at package was being removed or absent, which is inconsistent and can fail once the service unit is gone.

SOLUTION:
Introduce $manage_service = !($package_ensure in ['absent', 'purged']) and wrap the atd service resource in if $manage_service { ... } so the service is not declared when the package is not expected to be present. Document package_ensure accordingly, update REFERENCE.md, and add RSpec contexts for absent, purged, and latest.

TESTING METHODOLOGY:
CI.

OUTCOME:
Removing or purging the at package no longer triggers management of atd; installs using installed, present, latest, or a version string still get the service managed as before.