### PR TITLE
Harden rspec coverage of the at.allow allow-list

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -46,11 +46,10 @@ describe 'at' do
           it { is_expected.to create_at__user('foo') }
           it { is_expected.to create_at__user('bar') }
 
-          # root must always be permitted, in addition to any explicitly listed
-          # users -- otherwise enabling the allow-list would lock root out of
-          # at(1). The default-parameters context above only proves root is
-          # added when `users` is empty; this proves it is not dropped when
-          # users are supplied.
+          # root must always be permitted -- otherwise enabling the allow-list
+          # would lock root out of at(1). The manifest declares root
+          # unconditionally, independent of `users`, so this is a regression
+          # guard that root stays permitted regardless of what `users` contains.
           it { is_expected.to create_at__user('root') }
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -11,7 +11,18 @@ describe 'at' do
           it { is_expected.to create_class('at') }
           it { is_expected.to create_package('at') }
           it { is_expected.to create_at__user('root') }
-          it { is_expected.to create_concat('/etc/at.allow') }
+          # /etc/at.allow is the at(1) allow-list: only the users listed in it
+          # may schedule jobs. It must be root-owned and not world-readable (a
+          # readable allow-list leaks who is permitted to schedule work), so
+          # assert the mode/ownership, not merely that the file is managed.
+          it do
+            is_expected.to create_concat('/etc/at.allow')
+              .with(
+                owner: 'root',
+                group: 'root',
+                mode: '0600',
+              )
+          end
           it { is_expected.to create_file('/etc/at.deny').with({ ensure: 'absent' }) }
           it do
             is_expected.to create_service('atd')
@@ -34,6 +45,13 @@ describe 'at' do
           it { is_expected.to create_at__user('test') }
           it { is_expected.to create_at__user('foo') }
           it { is_expected.to create_at__user('bar') }
+
+          # root must always be permitted, in addition to any explicitly listed
+          # users -- otherwise enabling the allow-list would lock root out of
+          # at(1). The default-parameters context above only proves root is
+          # added when `users` is empty; this proves it is not dropped when
+          # users are supplied.
+          it { is_expected.to create_at__user('root') }
         end
       end
     end


### PR DESCRIPTION
Unit-test hardening, split out of the original combined PR #110 per review feedback.

- `init_spec.rb`: assert `/etc/at.allow` is root-owned and mode `0600` (a world-readable allow-list would leak who may schedule `at(1)` jobs), and that root remains permitted when an explicit `users` list is supplied.

Branches off `master`; independent of the AGENTS.md and acceptance PRs (linked below).


## Related PRs (split from #110)
- AGENTS.md config: #111
- rspec coverage: #112
- acceptance noop test: #113